### PR TITLE
Release v0.2.1: fix reliable PDF uploads for large collections

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -422,6 +422,7 @@ async function forwardSyncImpl(tab, notebookId, collectionId, collectionName, se
         }
 
         // Upload in batches via base64 drop
+        const RETRY_BACKOFFS_MS = [1500, 3000, 5000];
         for (let bi = 0; bi < resolvedFiles.length; bi += FILE_BATCH_SIZE) {
           const batch = resolvedFiles.slice(bi, bi + FILE_BATCH_SIZE);
           const batchFileData = batch.map(f => ({
@@ -432,7 +433,15 @@ async function forwardSyncImpl(tab, notebookId, collectionId, collectionName, se
 
           emitProgress("files", batch[0].item.title + (batch.length > 1 ? ` (+${batch.length - 1} more)` : ""));
 
-          const result = await injectFilesBatchViaCDP(tab.id, batchFileData);
+          let result = await injectFilesBatchViaCDP(tab.id, batchFileData);
+          let attempt = 1;
+          while (!result.success && attempt <= RETRY_BACKOFFS_MS.length) {
+            const backoff = RETRY_BACKOFFS_MS[attempt - 1];
+            console.warn(`[n2z] Upload failed for "${batch[0].item.title}" (attempt ${attempt}): ${result.error}. Retrying in ${backoff}ms…`);
+            await sleep(backoff);
+            result = await injectFilesBatchViaCDP(tab.id, batchFileData);
+            attempt++;
+          }
 
           for (const { item } of batch) {
             allResults.push({ title: item.title, success: result.success, error: result.error, type: "file" });
@@ -440,9 +449,10 @@ async function forwardSyncImpl(tab, notebookId, collectionId, collectionName, se
             doneCount++;
           }
 
-          // Small gap between batches
+          // Gap between batches — gives NotebookLM's async upload queue time to drain
+          // before the next dialog open. 2000ms matches the URL→file transition delay.
           if (bi + FILE_BATCH_SIZE < resolvedFiles.length) {
-            await sleep(800);
+            await sleep(2000);
           }
         }
       } finally {
@@ -473,12 +483,22 @@ async function forwardSyncImpl(tab, notebookId, collectionId, collectionName, se
 
   let message = `Synced ${successCount}/${newItems.length} items (${urlItems.length} URLs, ${fileItems.length} files).`;
   if (failCount > 0) {
-    const errors = allResults
-      .filter((r) => !r.success)
-      .slice(0, 3)
-      .map((r) => r.error)
+    const failed = allResults.filter((r) => !r.success);
+    const titlePreview = failed.slice(0, 5).map((r) => `"${r.title}"`).join(", ");
+    const remaining = failed.length - 5;
+    const titleSuffix = remaining > 0 ? `, +${remaining} more` : "";
+    message += ` ${failCount} failed: ${titlePreview}${titleSuffix}.`;
+
+    const errorCounts = new Map();
+    for (const r of failed) {
+      const key = r.error || "Unknown error";
+      errorCounts.set(key, (errorCounts.get(key) || 0) + 1);
+    }
+    const grouped = Array.from(errorCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([err, count]) => `${count}× "${err}"`)
       .join("; ");
-    message += ` Errors: ${errors}`;
+    message += ` Errors: ${grouped}`;
   }
 
   return {
@@ -751,6 +771,29 @@ async function injectFilesBatchViaCDP(tabId, filesData) {
     return { success: false, error: "No files provided" };
   }
 
+  // Step 0: If a prior dialog is still open (stale from a previous iteration),
+  // close it first so we start from a clean state. Without this, Step 1's
+  // "already-open" branch may use a stale dialog whose buttons have since
+  // been torn down, causing the upload-button query to miss.
+  const stalePresent = await chrome.scripting.executeScript({
+    target: { tabId },
+    func: () => {
+      const dialog = document.querySelector('[role="dialog"], mat-dialog-container');
+      return !!dialog;
+    },
+  });
+  if (stalePresent?.[0]?.result) {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true })),
+    });
+    await waitForInTab(
+      tabId,
+      () => !document.querySelector('[role="dialog"], mat-dialog-container'),
+      { timeoutMs: 3000, intervalMs: 150 }
+    );
+  }
+
   // Step 1: Ensure "Add sources" dialog is open. Poll up to 8s.
   const dialogOpened = await waitForInTab(
     tabId,
@@ -838,7 +881,7 @@ async function injectFilesBatchViaCDP(tabId, filesData) {
 
     let fileChooserResolve;
     const fileChooserPromise = new Promise(r => { fileChooserResolve = r; });
-    const chooserTimeout = setTimeout(() => fileChooserResolve(null), 8000);
+    const chooserTimeout = setTimeout(() => fileChooserResolve(null), 15000);
     onEvent = (source, method, params) => {
       if (source.tabId === tabId && method === "Page.fileChooserOpened") {
         clearTimeout(chooserTimeout);
@@ -912,7 +955,13 @@ async function injectFilesBatchViaCDP(tabId, filesData) {
     });
     await waitForInTab(
       tabId,
-      () => !/drop your files|upload files/i.test(document.body.textContent || ""),
+      () => {
+        // Prefer the dialog element — body text can match "upload files" in
+        // toasts or the sources list after upload completes.
+        const dialog = document.querySelector('[role="dialog"], mat-dialog-container');
+        if (dialog) return false;
+        return !/drop your files|upload files/i.test(document.body.textContent || "");
+      },
       { timeoutMs: 10000, intervalMs: 200 }
     );
 

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "NZBridge — NotebookLM Zotero Bridge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Bidirectional sync between Zotero collections and Google NotebookLM notebooks",
   "permissions": [
     "activeTab",

--- a/browser-extension/popup/popup.html
+++ b/browser-extension/popup/popup.html
@@ -126,7 +126,17 @@
     <p class="tab-description">Latest releases and upcoming features.</p>
 
     <div class="update-section">
-      <h3 class="update-version">v0.2.0 <span class="update-tag current">Current</span></h3>
+      <h3 class="update-version">v0.2.1 <span class="update-tag current">Current</span></h3>
+      <ul class="update-list">
+        <li>Fix: PDF uploads no longer silently drop files when syncing large collections — all PDFs now upload reliably</li>
+        <li>Up to 3 automatic retries per file with backoff if the upload dialog doesn't respond in time</li>
+        <li>Better error messages — shows exactly which PDFs failed and how many, instead of truncating to 3 errors</li>
+        <li>Note: upload time per file may be slightly longer than v0.2.0 to ensure reliability. Actual time depends on PDF size, your internet connection speed, and NotebookLM's response time</li>
+      </ul>
+    </div>
+
+    <div class="update-section">
+      <h3 class="update-version">v0.2.0</h3>
       <ul class="update-list">
         <li>Selective sync — choose exactly which PDFs and URLs to upload before syncing</li>
         <li>Real-time progress bar with per-file status and item counter</li>

--- a/zotero-plugin/package.json
+++ b/zotero-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nzbridge",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "NZBridge — Bidirectional sync between Zotero and Google NotebookLM",
   "config": {
     "addonName": "NZBridge",


### PR DESCRIPTION
## Summary

- Fix intermittent PDF upload failures when syncing large collections (30+ files) — each file now retries up to 3 times with backoff before being marked as failed
- Increase CDP file-chooser timeout from 8s to 15s for slow/loaded systems
- Close stale Add-sources dialogs before each upload cycle to prevent stale-button failures on retry
- Increase inter-file gap from 800ms to 2000ms to give NotebookLM time to drain its upload queue
- Improve error reporting: grouped counts and up to 5 failed PDF titles shown instead of truncating to 3 errors
- Bump all versions to 0.2.1

## Test plan

- [ ] Sync a collection with 30+ PDFs and confirm all upload without errors
- [ ] Confirm error messages show grouped counts and PDF titles when failures occur
- [ ] Confirm versions read 0.2.1 in both the Zotero plugin and browser extension
- [ ] Confirm Updates tab shows v0.2.1 as current with correct release notes