### PR TITLE
feat(localization): Add Turkish language support for NotebookLM UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Before installing NZBridge, make sure you have:
 
 > On **Chrome/Edge 142+**, you must allow the extension to reach Zotero on `localhost`: `chrome://extensions` → NZBridge → **Details** → **Site settings** → **Local network access** → **Allow**. See [Troubleshooting](#chromeedge-142-blocks-the-zotero-connection-local-network-access) if collections won't load or syncs time out.
 
-Note that it only works if your NotebookLM language settings is set to **english**.
+Note that it works with English, Turkish, Spanish, French, German, Chinese, Japanese, Korean, and other major language settings in NotebookLM (if your language is not supported, you may need to temporarily switch to English).
 ## Installation
 
 NZBridge has **two components** that work together — you need to install both:

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -353,6 +353,8 @@ async function forwardSyncImpl(
               !val ||
               /^untitled/i.test(val) ||
               /^new notebook/i.test(val) ||
+              /^adsız/i.test(val) ||
+              /^yeni/i.test(val) ||
               val.length < 3
             ) {
               const setter =
@@ -384,6 +386,8 @@ async function forwardSyncImpl(
               !text ||
               /^untitled/i.test(text) ||
               /^new notebook/i.test(text) ||
+              /^adsız/i.test(text) ||
+              /^yeni/i.test(text) ||
               text.length < 3
             ) {
               el.textContent = name;
@@ -437,6 +441,8 @@ async function forwardSyncImpl(
       const sourceTabLabels = [
         "sources",
         "source",
+        "kaynaklar",
+        "kaynak",
         "来源",
         "來源",
         "ソース",
@@ -1037,6 +1043,9 @@ async function addUrlSourcesBatch(tabId, urls) {
         "add source",
         "add sources",
         "add a source",
+        "kaynak ekle",
+        "kaynak ekleyin",
+        "kaynaklar",
         "添加来源",
         "添加源",
         "新增来源",
@@ -1214,6 +1223,12 @@ async function addUrlSourcesBatch(tabId, urls) {
         "links",
         "url",
         "urls",
+        "web sitesi",
+        "web siteleri",
+        "web sayfaları",
+        "bağlantı",
+        "bağlantılar",
+        "urller",
         "网站",
         "网页",
         "链接",
@@ -1307,6 +1322,9 @@ async function addUrlSourcesBatch(tabId, urls) {
         "paste",
         "link",
         "url",
+        "yapıştır",
+        "bağlantı",
+        "kopyala",
         "粘贴",
         "貼上",
         "链接",
@@ -1514,6 +1532,11 @@ async function addUrlSourcesBatch(tabId, urls) {
         "submit",
         "add source",
         "add sources",
+        "ekle",
+        "gönder",
+        "yerleştir",
+        "kaynak ekle",
+        "kaynakları ekle",
         "插入",
         "提交",
         "添加来源",
@@ -1907,6 +1930,9 @@ async function injectFilesBatchViaCDP(tabId, filesData) {
         "add source",
         "add sources",
         "add a source",
+        "kaynak ekle",
+        "kaynak ekleyin",
+        "kaynaklar",
         "添加来源",
         "添加源",
         "新增来源",
@@ -1936,7 +1962,7 @@ async function injectFilesBatchViaCDP(tabId, filesData) {
       ];
       const body = document.body.textContent || "";
       if (
-        /drop your files|upload files|drag.*files|拖放文件|拖拽文件|上传文件|上傳檔案|上傳文件|ファイルをアップロード|파일 업로드|subir archivos|téléverser|dateien hochladen|carregar arquivos|carica file|bestanden uploaden|unggah file/i.test(
+        /drop your files|upload files|drag.*files|dosya(ları|larınızı)?\s*(yükle|bırakın|sürükle)|拖放文件|拖拽文件|上传文件|上傳檔案|上傳文件|ファイルをアップロード|파일 업로드|subir archivos|téléverser|dateien hochladen|carregar arquivos|carica file|bestanden uploaden|unggah file/i.test(
           body,
         )
       ) {
@@ -1968,7 +1994,7 @@ async function injectFilesBatchViaCDP(tabId, filesData) {
     const ready = await waitForInTab(
       tabId,
       () =>
-        /drop your files|upload files|drag.*files|拖放文件|拖拽文件|上传文件|上傳檔案|上傳文件|ファイルをアップロード|파일 업로드|subir archivos|téléverser|dateien hochladen|carregar arquivos|carica file|bestanden uploaden|unggah file/i.test(
+        /drop your files|upload files|drag.*files|dosya(ları|larınızı)?\s*(yükle|bırakın|sürükle)|拖放文件|拖拽文件|上传文件|上傳檔案|上傳文件|ファイルをアップロード|파일 업로드|subir archivos|téléverser|dateien hochladen|carregar arquivos|carica file|bestanden uploaden|unggah file/i.test(
           document.body.textContent || "",
         ),
       { timeoutMs: 5000, intervalMs: 100 },
@@ -2026,6 +2052,10 @@ async function injectFilesBatchViaCDP(tabId, filesData) {
       "upload files",
       "upload file",
       "upload",
+      "dosya yükle",
+      "dosya yükleyin",
+      "yükle",
+      "dosyaları yükle",
       "上传文件",
       "上传",
       "上傳檔案",
@@ -2348,6 +2378,7 @@ function ensureStudioVisibleFn() {
   );
   const studioLabels = [
     "studio",
+    "stüdyo",
     "工作室",
     "工作區",
     "スタジオ",
@@ -3453,6 +3484,7 @@ async function extractNotesFromTab(tabId) {
         );
         const studioLabels = [
           "studio",
+          "stüdyo",
           "工作室",
           "工作區",
           "スタジオ",
@@ -3480,6 +3512,8 @@ async function extractNotesFromTab(tabId) {
           if (
             aria.includes("back") ||
             aria.includes("close") ||
+            aria.includes("geri") ||
+            aria.includes("kapat") ||
             aria.includes("返回") ||
             aria.includes("关闭") ||
             aria.includes("關閉") ||
@@ -3664,7 +3698,7 @@ async function getSourceState(tabId) {
         // Count strategy 1: explicit "N sources" text (virtualization-proof).
         let countFromText = null;
         const countRe =
-          /(\d+)\s*(sources?|来源|來源|ソース|소스|출처|fuentes?|quellen?|fontes?|fonti|bronnen|sumber)/i;
+          /(\d+)\s*(sources?|kaynak(lar)?|来源|來源|ソース|소스|출처|fuentes?|quellen?|fontes?|fonti|bronnen|sumber)/i;
         for (const el of document.querySelectorAll(
           'span, div, p, h1, h2, h3, button, [role="button"], [aria-label]',
         )) {

--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -37,6 +37,7 @@ async function prepareUploadDialog() {
     "aggiungi fonte", "aggiungi fonti",
     "bron toevoegen", "bronnen toevoegen",
     "tambahkan sumber",
+    "kaynak ekle", "kaynak ekleyin", "kaynaklar"
   ];
   const uploadLabels = [
     "upload files", "upload file", "upload",
@@ -50,6 +51,7 @@ async function prepareUploadDialog() {
     "carica file", "carica",
     "bestanden uploaden", "uploaden",
     "unggah file", "unggah",
+    "dosya yükle", "dosya yükleyin", "yükle", "dosyaları yükle"
   ];
   const hasAny = (text, labels) => labels.some((label) => text.includes(label));
 
@@ -65,6 +67,8 @@ async function prepareUploadDialog() {
     '[aria-label*="Add source" i]',
     '[aria-label*="Upload" i]',
     '[aria-label*="add source" i]',
+    '[aria-label*="kaynak ekle" i]',
+    '[aria-label*="yükle" i]',
     '[aria-label*="添加来源" i]',
     '[aria-label*="上传" i]',
     '[aria-label*="新增來源" i]',
@@ -123,7 +127,7 @@ async function prepareUploadDialog() {
   );
   for (const opt of uploadOptions) {
     const text = (opt.textContent || "").toLowerCase();
-    if (hasAny(text, uploadLabels) || text.includes("file") || text.includes("文件") || text.includes("檔案")) {
+    if (hasAny(text, uploadLabels) || text.includes("file") || text.includes("文件") || text.includes("檔案") || text.includes("dosya")) {
       opt.click();
       await sleep(800);
       fileInput = document.querySelector('input[type="file"]');

--- a/browser-extension/noteExtractor.js
+++ b/browser-extension/noteExtractor.js
@@ -47,6 +47,8 @@ async function extractSavedNotes() {
     '[data-panel="notes"]',
     '[aria-label*="Notes" i]',
     '[aria-label*="Saved" i]',
+    '[aria-label*="notlar" i]',
+    '[aria-label*="kaydedilen" i]',
     '[aria-label*="笔记" i]',
     '[aria-label*="已保存" i]',
     '[aria-label*="筆記" i]',
@@ -74,6 +76,7 @@ async function extractSavedNotes() {
     );
     const noteTabLabels = [
       "notes", "saved notes", "my notes",
+      "notlar", "kaydedilen notlar", "notlarım", "kaydedilenler",
       "笔记", "已保存的笔记", "我的笔记",
       "筆記", "已儲存的筆記", "我的筆記",
       "メモ", "ノート", "保存済みのメモ",

--- a/zotero-plugin/package-lock.json
+++ b/zotero-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "n2z",
-  "version": "0.1.0",
+  "name": "nzbridge",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "n2z",
-      "version": "0.1.0",
+      "name": "nzbridge",
+      "version": "0.4.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "zotero-plugin-toolkit": "^5.1.0-beta.13"


### PR DESCRIPTION
### Overview
This pull request introduces comprehensive Turkish language support to NZBridge. Previously, the extension required NotebookLM's language settings to be set to English. With these changes, the extension fully recognizes UI components, labels, and state indicators in Turkish.

### Key Changes
1. **Title Auto-Renaming Logic (`browser-extension/background.js`):**
   - Added support for matching Turkish default untitled notebook names (`"Adsız not defteri"`, `"Yeni not defteri"`) when renaming the notebook to Zotero's collection name.

2. **Source tab & count matches (`browser-extension/background.js`):**
   - Added `"kaynaklar"` and `"kaynak"` to the source tab labels list.
   - Updated the count regex (`countRe`) to match Turkish source counts (e.g., `"0 kaynak"`).

3. **Batch URL Upload / Web Pages (`browser-extension/background.js`):**
   - Added `"web siteleri"`, `"web sitesi"`, `"bağlantı"`, `"bağlantılar"`, `"urller"` to `websiteLabels`.
   - Added `"yapıştır"`, `"bağlantı"`, `"kopyala"` to `urlFieldLabels`.
   - Added `"ekle"`, `"gönder"`, `"yerleştir"`, `"kaynak ekle"`, `"kaynakları ekle"` to `insertLabels` for the submit step.

4. **File Uploading / Drag & Drop (`browser-extension/content.js` & `background.js`):**
   - Added `"kaynak ekle"`, `"kaynak ekleyin"`, `"kaynaklar"` to `addSourceLabels`.
   - Added `"dosya yükle"`, `"dosya yükleyin"`, `"yükle"`, `"dosyaları yükle"` to `uploadLabels`.
   - Updated drag-and-drop dialog check regex to match `"veya dosyalarınızı bırakın"`.

5. **Saved Notes Panel / Studio (`browser-extension/noteExtractor.js` & `background.js`):**
   - Added `"notlar"`, `"kaydedilen notlar"`, `"notlarım"`, `"kaydedilenler"` to the notes tab detection.
   - Added `"stüdyo"` to studio tab labels.
   - Handled back/close actions with Turkish aria-labels (e.g. `"geri"`, `"kapat"`).

6. **Documentation (`README.md`):**
   - Updated the language requirement note in the README to mention Turkish and other major languages are supported.

### Verification
Tested on a Turkish-configured Google account and verified that:
- Default notebooks are renamed to the collection name.
- Web URLs are successfully added to source lists.
- Saved notes (Studio panel) are successfully read, extracted, and synchronized.
