### PR TITLE
Fix Gemini Notebook domain detection

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -23,7 +23,26 @@ const cancelledSyncs = new Set();
 // Shape: { phase, current, total, currentTitle, done, result }
 const syncProgress = new Map();
 
-const NOTEBOOKLM_URL_PREFIX = "https://notebooklm.google.com/";
+// Gemini Notebook now uses notebook.google.com. Keep the legacy NotebookLM
+// host during the rollout because existing accounts and links may use either.
+const NOTEBOOK_URL_PATTERNS = [
+  "https://notebook.google.com/*",
+  "https://notebooklm.google.com/*",
+];
+
+function isNotebookUrl(url) {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return (
+      ["notebook.google.com", "notebooklm.google.com"].includes(
+        parsed.hostname,
+      ) && parsed.pathname.startsWith("/notebook/")
+    );
+  } catch {
+    return false;
+  }
+}
 const AMBIGUOUS_TAB_ERROR =
   "Multiple NotebookLM tabs are open. Please switch to the notebook you want to sync into and try again.";
 
@@ -187,13 +206,16 @@ async function resolveNotebookLMTab(preferredNotebookId = null) {
     lastFocusedWindow: true,
   });
   const active = activeTabs[0];
-  if (active?.url?.startsWith(NOTEBOOKLM_URL_PREFIX)) {
+  if (isNotebookUrl(active?.url)) {
     return { tab: active, reason: "active" };
   }
 
-  const allNotebookLMTabs = await chrome.tabs.query({
-    url: "https://notebooklm.google.com/*",
+  const candidateTabs = await chrome.tabs.query({
+    url: NOTEBOOK_URL_PATTERNS,
   });
+  const allNotebookLMTabs = candidateTabs.filter((tab) =>
+    isNotebookUrl(tab.url),
+  );
 
   if (preferredNotebookId) {
     const match = allNotebookLMTabs.find((t) =>

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -6,6 +6,7 @@
   "permissions": ["activeTab", "scripting", "debugger", "storage"],
   "host_permissions": [
     "http://localhost:23119/*",
+    "https://notebook.google.com/*",
     "https://notebooklm.google.com/*"
   ],
   "background": {
@@ -21,7 +22,10 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://notebooklm.google.com/*"],
+      "matches": [
+        "https://notebook.google.com/*",
+        "https://notebooklm.google.com/*"
+      ],
       "js": ["content.js", "noteExtractor.js"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
## Summary

- allow the browser extension to run on `notebook.google.com`
- detect notebook tabs on both the new Gemini Notebook host and the legacy NotebookLM host
- require the `/notebook/` path so ordinary `gemini.google.com` pages are not treated as notebook workspaces

## Root cause

Gemini Notebook moved its standalone workspace to
`https://notebook.google.com/notebook/<id>`, while both the manifest and the
background tab resolver still matched only `notebooklm.google.com`. The popup
therefore reported `No NotebookLM tab found` even when a Gemini Notebook was
open.

## Impact

This restores forward and backward sync on the renamed product while retaining
compatibility with legacy NotebookLM URLs during the rollout.

## Validation

- ran `node --check` on all browser-extension JavaScript files
- parsed `browser-extension/manifest.json` as JSON
- tested five URL-detection cases covering new, legacy, homepage, ordinary
  Gemini app, and malformed URLs
- manually verified the unpacked extension against a live
  `notebook.google.com/notebook/...` workspace
